### PR TITLE
Skript crashes after start of reactor

### DIFF
--- a/Draconic-Evolution-Reactor-Controller.lua
+++ b/Draconic-Evolution-Reactor-Controller.lua
@@ -3,7 +3,7 @@ local version = "1.0"
 local reactorSide = "left"
 local outputfluxgateSide = "top"
 
-local targetStrength = 50
+local targetFieldStrengthPercent = 50
 local maxTemperature = 8000
 local safeTemperature = 7500
 local lowestFieldPercent = 25


### PR DESCRIPTION
I suppose its a writing error because if i do this change it all work great.

The variable targetFieldStrengthPercent wasnt defined and targetStrength isnt used anywhere

Without the Skript crashes in Line 280 after the reactor starts